### PR TITLE
Add devcontainer to run in codespaces

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -1,0 +1,9 @@
+{
+  "name": "vscode-dvc-demo",
+  "image": "mcr.microsoft.com/devcontainers/python:3.10",
+  "extensions": ["Iterative.dvc", "ms-python.python", "redhat.vscode-yaml"],
+  "features": {
+      "ghcr.io/iterative/features/dvc:1": {}
+  },
+  "postCreateCommand": "pip3 install --user -r requirements.txt"
+}


### PR DESCRIPTION
Per https://github.com/iterative/vscode-dvc/issues/2830#issuecomment-1331434914 to be able to run it in Codespaces.

<img width="1512" alt="Screen Shot 2022-11-29 at 4 14 49 PM" src="https://user-images.githubusercontent.com/3659196/204676595-0b4515c2-9269-4a04-a953-8951a1a6d89b.png">

Issue is reproducible when I'm trying to run it.
