### PR TITLE
Add DVCLive as an explict dependency (removed from DVC)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 dvc[s3]==2.47.0
 torch==1.13.1
 torchvision==0.14.1
+dvclive==2.3.1


### PR DESCRIPTION
DVCLive was dropped as a dependency from DVC here: https://github.com/iterative/dvc/pull/9105

We need to add it to our requirements to get the e2e tests to pass here: https://github.com/iterative/vscode-dvc/pull/3438